### PR TITLE
issue-17/add_abbrev_tmcont

### DIFF
--- a/report_90x.py
+++ b/report_90x.py
@@ -93,6 +93,7 @@ TMQC_COLS = [
 # map abbrev (from merge_name in input report) to the Study/Cohort name
 COLLECTION_LIST = [
     ("Legacy", "TOPMed Control"),
+    ("TMCONT", "TOPMed Control"),
     ("TMHASC", "Harvard SCD"),
     ("TMCGVC", "Causal Genetic Variants of Cardiomyopathy"),
     ("TMGCUC", "Genetic Causes of Unexplained Cardiomyopathies"),

--- a/report_merged_qc_results.py
+++ b/report_merged_qc_results.py
@@ -97,6 +97,7 @@ RPT_COLS = [
 # map abbrev (from merge_name in input report) to the Study/Cohort name
 COLLECTION_LIST = [
     ("Legacy", "TOPMed Control"),
+    ("TMCONT", "TOPMed Control"),
     ("TMHASC", "Harvard SCD"),
     ("TMCGVC", "Causal Genetic Variants of Cardiomyopathy"),
     ("TMGCUC", "Genetic Causes of Unexplained Cardiomyopathies"),


### PR DESCRIPTION
The abbrev for TOPMed Control has been corrected in Exemplar LIMS.
From `Legacy` to `TMCONT`.

`COLLECTION_LIST` has been updated to reflect this change:

-  keep `Legacy` to deal with any old issues
-  add `TMCONT`
