### PR TITLE
issue 39/fix logger name

### DIFF
--- a/pm_utils/business.py
+++ b/pm_utils/business.py
@@ -16,7 +16,7 @@ from .utils import normalize_name
 from .rpt_columns import rpt_merge_cols
 from .mappings import STUDY_MAPPING
 
-logger = logging.getLogger(__main__)
+logger = logging.getLogger(__name__)
 
 
 def load_merge_report(recent_merge_report):


### PR DESCRIPTION
Fixes #39.

Use `__name__` instead of `__main__`.