### PR TITLE
Issue 45/fix importlib metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,14 +21,14 @@ classifiers =
     Intended Audience :: System Administrators
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 # The package names (import):
-python_requires = >=3.8
+python_requires = >=3.9
 # You don't need package_dir if your packeges are at the top.
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ url = https://github.com/BCM-HGSC
 license = MIT
 # https://pypi.org/classifiers/
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Developers
     Intended Audience :: Information Technology

--- a/src/pm_utils/__init__.py
+++ b/src/pm_utils/__init__.py
@@ -6,11 +6,7 @@ Here we just fetch the version from the distribution and expose as __version__.
 
 # Machinery to extract the version from package metadata.
 
-# Support Python < 3.8:
-try:
-    from importlib.metadata import version as _version
-except ModuleNotFoundError:
-    from importlib_metadata import version as _version
+from importlib.metadata import version as _version
 
 # Passing in the distribution name which is not always the package name:
 __version__ = _version("pm_utils")


### PR DESCRIPTION
Resolves #45.

Fix `ModuleNotFoundError` for `importlib_metadata`.

Changes:
- Drop support for Python versions prior to 3.9, ensuring compatibility and leveraging features available in newer versions

Additionally:
- Change Development Status to Production/Stable
